### PR TITLE
Добавить кнопку «Админка» в меню для координаторов проектов

### DIFF
--- a/Bastilia.Rating.Portal/Components/Layout/NavMenu.razor
+++ b/Bastilia.Rating.Portal/Components/Layout/NavMenu.razor
@@ -35,6 +35,15 @@
             </NavLink>
         </div>
 
+        @if (AdminProjectIds is { Count: > 0 })
+        {
+            <div class="nav-item px-3">
+                <NavLink class="nav-link" href="admin">
+                    <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Админка
+                </NavLink>
+            </div>
+        }
+
         <AuthorizeView>
             <Authorized>
                 <div class="nav-item px-3 auth-block">
@@ -57,4 +66,9 @@
         </AuthorizeView>
     </nav>
 </div>
+
+@code {
+    [CascadingParameter]
+    private HashSet<int>? AdminProjectIds { get; set; }
+}
 


### PR DESCRIPTION
## Summary
- Показывать пункт меню «Админка» пользователям, у которых есть доступ хотя бы к одному проекту (председатель или координатор), переиспользуя уже вычисляемый в `MainLayout` каскадный `AdminProjectIds`.

## Test plan
- [x] `dotnet build`