### PR TITLE
Fix project completion form: stale rows and no refresh after submit

### DIFF
--- a/Bastilia.Rating.Portal/Components/Pages/Admin/Project/CompleteProjectForm.razor
+++ b/Bastilia.Rating.Portal/Components/Pages/Admin/Project/CompleteProjectForm.razor
@@ -1,4 +1,6 @@
 @inject IProjectService projectService
+@inject NavigationManager navigationManager
+@rendermode InteractiveServer
 
 <Card>
     <Header>Завершить проект</Header>
@@ -74,6 +76,7 @@
 
         await projectService.CompleteProject(ProjectId, Model.EndDate, Model.ProjectLevel, names);
         await OnCompleted.InvokeAsync();
+        navigationManager.NavigateTo(navigationManager.Uri, forceLoad: true);
     }
 
     private class CompleteViewModel


### PR DESCRIPTION
## Summary
- Форма завершения проекта (`CompleteProjectForm.razor`) рендерилась в статическом SSR-режиме, поэтому переключение выпадашки уровня проекта не пересчитывало видимый список полей для названий ачивок.
- После сабмита формы родительская страница (`Index.razor`) тоже не обновлялась, так как не имеет живого circuit — компонент лишь менял состояние на сервере, но браузер об этом не узнавал.
- Компонент переведён в `@rendermode InteractiveServer`, что чинит live-обновление списка строк при смене уровня, а после успешного завершения выполняется `NavigateTo(..., forceLoad: true)` для полной перезагрузки страницы с актуальным состоянием.

## Test plan
- [x] `dotnet build ./Bastilia.Rating.Portal/Bastilia.Rating.Portal.csproj`
- [ ] Вручную проверить в браузере: смена уровня в форме завершения проекта обновляет список полей ачивок, а после нажатия «Завершить проект» страница обновляется и форма скрывается

🤖 Generated with [Claude Code](https://claude.com/claude-code)