### PR TITLE
Не показывать «Вписаться» для завершённых проектов

### DIFF
--- a/Bastilia.Rating.Portal.Client/Components/Projects/HelpRequiredBadge.razor
+++ b/Bastilia.Rating.Portal.Client/Components/Projects/HelpRequiredBadge.razor
@@ -1,4 +1,4 @@
-@if (!string.IsNullOrWhiteSpace(HowToHelp))
+@if (Required)
 {
     <Tooltip Title="@HowToHelp">
         <span class="badge bg-warning">
@@ -8,6 +8,9 @@
 }
 @code
 {
+    [Parameter, EditorRequired]
+    public bool Required { get; set; }
+
     [Parameter, EditorRequired]
     public string HowToHelp { get; set; } = null!;
 }

--- a/Bastilia.Rating.Portal.Client/Components/Projects/ProjectList.razor
+++ b/Bastilia.Rating.Portal.Client/Components/Projects/ProjectList.razor
@@ -20,7 +20,7 @@
     @if (Projects.Any(x => x.HelpRequired))
     {
         <TemplateColumn Context="project" Title="Вписаться?" SortBy="GridSort<BastiliaProject>.ByAscending(p => p.HelpRequired)">
-           <HelpRequiredBadge HowToHelp="@project.HowToHelp"/>
+           <HelpRequiredBadge Required="@project.HelpRequired" HowToHelp="@project.HowToHelp"/>
         </TemplateColumn>
     }
     <TemplateColumn Context="project" Title="Глава/Координатор">


### PR DESCRIPTION
## Summary
- `HelpRequiredBadge` проверял только наличие текста `HowToHelp`, минуя доменное свойство `BastiliaProject.HelpRequired`, которое уже учитывает статус проекта через `IsActive`
- В `ProjectList.razor` это приводило к тому, что бейдж «требуется участие» мог показываться для завершённых проектов
- Компонент теперь принимает флаг `Required`, привязанный к `project.HelpRequired`

## Test plan
- [x] `dotnet build` проходит успешно
- [ ] Визуально проверить список проектов: у завершённых проектов бейдж «Вписаться» не отображается

🤖 Generated with [Claude Code](https://claude.com/claude-code)